### PR TITLE
[decoupled-kit-acf] Ensure Related Content Field Group is Exposed via WPGraphQL

### DIFF
--- a/decoupled-kit-acf.php
+++ b/decoupled-kit-acf.php
@@ -96,7 +96,7 @@ function create_acf() {
 			'active' => true,
 			'description' => '',
 			'show_in_rest' => 0,
-			'show_in_graphql' => 0,
+			'show_in_graphql' => 1,
 			'graphql_field_name' => 'relatedContent',
 			'map_graphql_types_from_location_rules' => 0,
 			'graphql_types' => '',


### PR DESCRIPTION
Opening a new PR here - was seeing an unexpected diff with the other PR.